### PR TITLE
msm: ais: fix './ais_isp_trace.h' file not found

### DIFF
--- a/drivers/media/platform/msm/ais/ais_isp/utils/Makefile
+++ b/drivers/media/platform/msm/ais/ais_isp/utils/Makefile
@@ -5,5 +5,7 @@ ccflags-y += -Idrivers/media/platform/msm/ais/cam_smmu/
 ccflags-y += -Idrivers/media/platform/msm/ais/cam_sync
 ccflags-y += -Idrivers/media/platform/msm/ais/cam_utils
 ccflags-y += -Idrivers/media/platform/msm/ais/cam_cdm/
+# Tell define_trace.h where to find ais_isp_trace.h
+ccflags-y += -I$(src)
 
 obj-$(CONFIG_MSM_AIS) += ais_isp_trace.o


### PR DESCRIPTION
This is a fix for the following error found when
compiling vmlinux:

>>>>
In file included from drivers/media/platform/msm/ais/ais_isp/utils/ais_isp_trace.c:16:
In file included from drivers/media/platform/msm/ais/ais_isp/utils/ais_isp_trace.h:229:
./include/trace/define_trace.h:89:10: fatal error: './ais_isp_trace.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./include/trace/define_trace.h:84:32: note: expanded from macro 'TRACE_INCLUDE'
                               ^~~~~~~~~~~~~~~~~~~~~~~
./include/trace/define_trace.h:81:34: note: expanded from macro '__TRACE_INCLUDE'
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./include/linux/stringify.h:10:27: note: expanded from macro '__stringify'
                                ^~~~~~~~~~~~~~~~
./include/linux/stringify.h:9:29: note: expanded from macro '__stringify_1'
                                ^~
<scratch space>:13:1: note: expanded from here
"./ais_isp_trace.h"
^~~~~~~~~~~~~~~~~~~
  CC      drivers/media/platform/msm/ais/ais_isp/csid_hw/ais_ife_csid17x.o
  CC      lib/idr.o
1 error generated.
<<<<

Tell define_trace.h where to find ais_isp_trace.h header.

Upstream Status: pending

Change-Id: I6d2338d09cdadcb4585dc722edc662d781097ed1
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>