### PR TITLE
Clk qcom gdsc lockdep warn

### DIFF
--- a/drivers/clk/qcom/gdsc-regulator.c
+++ b/drivers/clk/qcom/gdsc-regulator.c
@@ -689,6 +689,8 @@ static const struct regmap_config gdsc_regmap_config = {
 	.fast_io    = true,
 };
 
+static struct lock_class_key gdsc_reg_lock_key;
+
 static int gdsc_probe(struct platform_device *pdev)
 {
 	static atomic_t gdsc_count = ATOMIC_INIT(-1);
@@ -1019,6 +1021,9 @@ static int gdsc_probe(struct platform_device *pdev)
 		ret = PTR_ERR(sc->rdev);
 		goto err;
 	}
+
+	/* Create lockdep class to avoid false positive lock warnings */
+	lockdep_set_class(&sc->rdev->mutex, &gdsc_reg_lock_key);
 
 	return 0;
 


### PR DESCRIPTION
    The regulator lockdep class is too broad for the qcom gdsc driver
    and causes a false positive recursive locking warning when lockdep
    is enabled. This change creates a gdsc regulator lockdep class so
    the driver can lock its device and supply regulators without
    producing a lockdep warning. The following warning is removed:
    
    ============================================
    WARNING: possible recursive locking detected
    4.14.156 #1 Tainted: G S W
    --------------------------------------------
    swapper/0/1 is trying to acquire lock:
    (&rdev->mutex)\{+.+.}, at: [< (ptrval)>] regulator_lock_supply+0x28/0x48
    
    but task is already holding lock:
    (&rdev->mutex)\{+.+.}, at: [< (ptrval)>] regulator_enable+0x48/0x194
    
    other info that might help us debug this:
    Possible unsafe locking scenario:
    
    CPU0
    ----
    lock(&rdev->mutex);
    lock(&rdev->mutex);
    
    *** DEADLOCK ***
    
    May be due to missing lock nesting notation
    
    4 locks held by swapper/0/1:
    
    stack backtrace:
    CPU: 7 PID: 1 Comm: swapper/0 Tainted: G S W 4.14.156 #1
    Hardware name: Qualcomm Technologies, Inc. SA8155P v2 PM8150 ADP-MGU (DT)
    Call trace:
    dump_backtrace+0x0/0x234
    show_stack+0x20/0x2c
    dump_stack+0xe4/0x134
    __lock_acquire+0x564/0x14d4
    lock_acquire+0x21c/0x254
    __mutex_lock_common+0xac/0xb48
    mutex_lock_nested+0x40/0x50
    regulator_lock_supply+0x28/0x48
    regulator_set_voltage+0x28/0x5c
    gdsc_enable+0x50/0x508
    _regulator_do_enable+0x2c4/0x66c
    regulator_enable+0x114/0x194
    arm_smmu_power_on+0xa8/0x198
    arm_smmu_device_dt_probe+0x3dc/0x1230
    platform_drv_probe+0x5c/0xb0
    driver_probe_device+0x2ec/0x420
    __driver_attach+0xbc/0x15c
    bus_for_each_dev+0x8c/0xd4
    driver_attach+0x2c/0x38
    bus_add_driver+0x138/0x240
    driver_register+0x90/0xdc
    __platform_driver_register+0x4c/0x58
    arm_smmu_init+0x7c/0x240
    _arm_smmu_init+0x24/0x2c
    do_one_initcall+0xe0/0x1b4
    kernel_init_freeable+0x1f4/0x28c
    kernel_init+0x14/0x160
    ret_from_fork+0x10/0x18