### PR TITLE
msm: npu: fix for LKM build

### DIFF
--- a/drivers/devfreq/devfreq_devbw.c
+++ b/drivers/devfreq/devfreq_devbw.c
@@ -255,6 +255,7 @@ int devfreq_suspend_devbw(struct device *dev)
 
 	return devfreq_suspend_device(d->df);
 }
+EXPORT_SYMBOL(devfreq_suspend_devbw);
 
 int devfreq_resume_devbw(struct device *dev)
 {
@@ -262,6 +263,7 @@ int devfreq_resume_devbw(struct device *dev)
 
 	return devfreq_resume_device(d->df);
 }
+EXPORT_SYMBOL(devfreq_resume_devbw);
 
 static int devfreq_devbw_probe(struct platform_device *pdev)
 {


### PR DESCRIPTION
A partial fix to the kernel multimedia drivers to allow the msm
NPU driver to be built as a loadable kernel module. This allows
the following kernel configuration item to be set as a module:

CONFIG_MSM_NPU=m

This results in the following loadable kernel module:

msm_npu.ko

Without this fix, a module build of the msm NPU driver will
result in the following errors:

ERROR: "devfreq_resume_devbw" [drivers/media/platform/msm/npu/
msm_npu.ko] undefined!
ERROR: "devfreq_suspend_devbw" [drivers/media/platform/msm/npu
/msm_npu.ko] undefined!

Signed-off-by: Kevin Vasilik <Kevin.Vasilik@garmin.com>