### PR TITLE
sound: usb: Fix USB Audio QMI Svc driver LKM build

### DIFF
--- a/sound/usb/card.c
+++ b/sound/usb/card.c
@@ -178,6 +178,7 @@ err:
 	mutex_unlock(&register_mutex);
 	return subs;
 }
+EXPORT_SYMBOL_GPL(find_snd_usb_substream);
 
 /*
  * disconnect streams

--- a/sound/usb/helper.c
+++ b/sound/usb/helper.c
@@ -75,6 +75,7 @@ void *snd_usb_find_csint_desc(void *buffer, int buflen, void *after, u8 dsubtype
 	}
 	return NULL;
 }
+EXPORT_SYMBOL_GPL(snd_usb_find_csint_desc);
 
 /*
  * Wrapper for usb_control_msg().

--- a/sound/usb/pcm.c
+++ b/sound/usb/pcm.c
@@ -710,6 +710,7 @@ int snd_usb_enable_audio_stream(struct snd_usb_substream *subs,
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(snd_usb_enable_audio_stream);
 
 /*
  * Return the score of matching two audioformats.

--- a/sound/usb/usb_audio_qmi_v01.c
+++ b/sound/usb/usb_audio_qmi_v01.c
@@ -391,6 +391,7 @@ struct qmi_elem_info qmi_uaudio_stream_req_msg_v01_ei[] = {
 		.is_array       = QMI_COMMON_TLV_TYPE,
 	},
 };
+EXPORT_SYMBOL_GPL(qmi_uaudio_stream_req_msg_v01_ei);
 
 struct qmi_elem_info qmi_uaudio_stream_resp_msg_v01_ei[] = {
 	{
@@ -694,6 +695,7 @@ struct qmi_elem_info qmi_uaudio_stream_resp_msg_v01_ei[] = {
 		.is_array       = QMI_COMMON_TLV_TYPE,
 	},
 };
+EXPORT_SYMBOL_GPL(qmi_uaudio_stream_resp_msg_v01_ei);
 
 struct qmi_elem_info qmi_uaudio_stream_ind_msg_v01_ei[] = {
 	{
@@ -905,3 +907,4 @@ struct qmi_elem_info qmi_uaudio_stream_ind_msg_v01_ei[] = {
 		.is_array       = QMI_COMMON_TLV_TYPE,
 	},
 };
+EXPORT_SYMBOL_GPL(qmi_uaudio_stream_ind_msg_v01_ei);


### PR DESCRIPTION
The QMI USB Audio Service driver type is tristate but will fail
to build if set as a loadable module. This fix exports necessary
symbols to allow this driver to be built as a module. Kernel
configuration parameter is:

SND_USB_AUDIO_QMI=m

Resulting kernel modules include:

usb_audio_qmi_v01.ko
usb_audio_qmi_svc.ko

Without this fix, a module build of the QMI USB Audio Service
driver will result in the following errors:

ERROR: "qmi_uaudio_stream_req_msg_v01_ei" [sound/usb/usb_audio
_qmi_svc.ko] undefined!
ERROR: "qmi_uaudio_stream_ind_msg_v01_ei" [sound/usb/usb_audio
_qmi_svc.ko] undefined!
ERROR: "snd_usb_find_csint_desc" [sound/usb/usb_audio_qmi_svc.
ko] undefined!
ERROR: "qmi_uaudio_stream_resp_msg_v01_ei" [sound/usb/usb_audi
o_qmi_svc.ko] undefined!
ERROR: "snd_usb_enable_audio_stream" [sound/usb/usb_audio_qmi_
svc.ko] undefined!
ERROR: "find_snd_usb_substream" [sound/usb/usb_audio_qmi_svc.k
o] undefined!

Signed-off-by: Kevin Vasilik <Kevin.Vasilik@garmin.com>