### PR TITLE
msm: vidc: fix for LKM build

### DIFF
--- a/drivers/media/platform/msm/vidc/msm_vidc.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc.c
@@ -28,6 +28,8 @@
 
 #define MAX_EVENTS 30
 
+EXPORT_TRACEPOINT_SYMBOL(msm_vidc_perf_bus_vote);
+
 static int try_get_ctrl(struct msm_vidc_inst *inst,
 	struct v4l2_ctrl *ctrl);
 

--- a/drivers/media/platform/msm/vidc/msm_vidc_platform.c
+++ b/drivers/media/platform/msm/vidc/msm_vidc_platform.c
@@ -921,7 +921,7 @@ static struct msm_vidc_platform_data sdm670_data = {
 	.vpu_ver = VPU_VERSION_4,
 };
 
-static const struct of_device_id msm_vidc_dt_match[] = {
+static const struct of_device_id msm_vidc_dt_match_plat[] = {
 	{
 		.compatible = "qcom,atoll-vidc",
 		.data = &atoll_data,
@@ -957,7 +957,7 @@ static const struct of_device_id msm_vidc_dt_match[] = {
 	{},
 };
 
-MODULE_DEVICE_TABLE(of, msm_vidc_dt_match);
+MODULE_DEVICE_TABLE(of, msm_vidc_dt_match_plat);
 
 static int msm_vidc_read_efuse(
 		struct msm_vidc_platform_data *data, struct device *dev)
@@ -1013,7 +1013,7 @@ void *vidc_get_drv_data(struct device *dev)
 		goto exit;
 	}
 
-	match = of_match_node(msm_vidc_dt_match, dev->of_node);
+	match = of_match_node(msm_vidc_dt_match_plat, dev->of_node);
 
 	if (match)
 		driver_data = (struct msm_vidc_platform_data *)match->data;


### PR DESCRIPTION
A partial fix to the kernel multimedia drivers to allow the msm vidc
driver to be built as loadable kernel modules. This allows the
following kernel configuration items to be set as modules:

CONFIG_MSM_VIDC_V4L2=m
CONFIG_MSM_VIDC_GOVERNORS=m

This results in the foollowing loadable kernel modules:

msm-vidc.ko
msm-vidc-ar50-dyn-gov.ko
msm-vidc-dyn-gov.ko

Signed-off-by: Kevin Vasilik <Kevin.Vasilik@garmin.com>