### PR TITLE
power: reset: msm-poweroff: lower printk prio for DLOAD,EDLOAD DT props

### DIFF
--- a/drivers/power/reset/msm-poweroff.c
+++ b/drivers/power/reset/msm-poweroff.c
@@ -607,7 +607,7 @@ static int msm_restart_probe(struct platform_device *pdev)
 	atomic_notifier_chain_register(&panic_notifier_list, &panic_blk);
 	np = of_find_compatible_node(NULL, NULL, DL_MODE_PROP);
 	if (!np) {
-		pr_err("unable to find DT imem DLOAD mode node\n");
+		pr_debug("unable to find DT imem DLOAD mode node\n");
 	} else {
 		dload_mode_addr = of_iomap(np, 0);
 		if (!dload_mode_addr)
@@ -616,7 +616,7 @@ static int msm_restart_probe(struct platform_device *pdev)
 
 	np = of_find_compatible_node(NULL, NULL, EDL_MODE_PROP);
 	if (!np) {
-		pr_err("unable to find DT imem EDLOAD mode node\n");
+		pr_debug("unable to find DT imem EDLOAD mode node\n");
 	} else {
 		emergency_dload_mode_addr = of_iomap(np, 0);
 		if (!emergency_dload_mode_addr)


### PR DESCRIPTION
Following error level messages are noticed in kernel log:
>>>>
[    2.414659] unable to find DT imem DLOAD mode node
[    2.415149] unable to find DT imem EDLOAD mode node
<<<<

These correspond to qcom,msm-imem-download_mode and
qcom,msm-imem-emergency_download_mode. Since these devicetree
properties are not mandatory, reduce the printk priority
to debug level.

Change-Id: I5caca9bb755eaa4e9a58514616a67de5079fc7dc
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>