### PR TITLE
msm: pcie: fix printk prio for 'RC0 is enabled in bootup'

### DIFF
--- a/drivers/pci/host/pci-msm.c
+++ b/drivers/pci/host/pci-msm.c
@@ -6225,7 +6225,7 @@ static int msm_pcie_probe(struct platform_device *pdev)
 			"PCIe: RC%d is not enabled during bootup; it will be enumerated upon client request.\n",
 			rc_idx);
 	else
-		PCIE_ERR(&msm_pcie_dev[rc_idx], "RC%d is enabled in bootup\n",
+		PCIE_INFO(&msm_pcie_dev[rc_idx], "RC%d is enabled in bootup\n",
 			rc_idx);
 
 	PCIE_DBG(&msm_pcie_dev[rc_idx], "PCIE probed %s\n",


### PR DESCRIPTION
Following kernel message is seen at KERN_ERR level:
>>>>
[    2.600412] msm_pcie_probe: RC0 is enabled in bootup
<<<<

This message is printed after successful return from
msm_pcie_enumerate(). Hence reduce its printk prio to
KERN_INFO instead.

Change-Id: If4cf296e44a2004fa4089e535cdd2abc74541593
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>