### PR TITLE
pinctrl: msm: fix error handling for pdc resource

### DIFF
--- a/drivers/pinctrl/qcom/pinctrl-msm.c
+++ b/drivers/pinctrl/qcom/pinctrl-msm.c
@@ -2091,7 +2091,8 @@ int msm_pinctrl_probe(struct platform_device *pdev,
 
 	key = "pdc";
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, key);
-	pctrl->pdc_regs = devm_ioremap_resource(&pdev->dev, res);
+	if (res)
+		pctrl->pdc_regs = devm_ioremap_resource(&pdev->dev, res);
 
 	key = "spi_cfg";
 	res = platform_get_resource_byname(pdev, IORESOURCE_MEM, key);


### PR DESCRIPTION
pdc platform resource is retrieved from devicetree and then
mapped for use. The resource is mapped without checking
for its existence in devicetree which results into the
following error:
>>>>
[    2.387577] sm8150-pinctrl 3000000.pinctrl: invalid resource
<<<<

Map the resource only if it is supplied through devicetree.

Change-Id: Iee9c72e45dbd3ae06d5e7b573a1d6a1b3edcbd33
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>