### PR TITLE
qseecom: lower msg prio for 'Unable to register bus client'

### DIFF
--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -9258,6 +9258,9 @@ static int qseecom_probe(struct platform_device *pdev)
 		qseecom.timer_running = false;
 		qseecom.qsee_perf_client = msm_bus_scale_register_client(
 		      qseecom_platform_support);
+
+		if (!qseecom.qsee_perf_client)
+			pr_err("Unable to register bus client\n");
 	}
 
 	qseecom.whitelist_support = qseecom_check_whitelist_feature();
@@ -9287,9 +9290,6 @@ static int qseecom_probe(struct platform_device *pdev)
 	}
 	atomic_set(&qseecom.unload_app_kthread_state,
 						UNLOAD_APP_KT_SLEEP);
-
-	if (!qseecom.qsee_perf_client)
-		pr_err("Unable to register bus client\n");
 
 	atomic_set(&qseecom.qseecom_state, QSEECOM_STATE_READY);
 	return 0;


### PR DESCRIPTION
This error message was introduced in Commit 683f99243fae
("qseecom: register qseecom client with msm bus driver")

This error is generated when the qseecom driver looks for
qom,support-bus-scaling property in devicetree and such an
entry is not found. In this case, driver does not error out
on probe so lower the message priority from pr_err to pr_dbg.

Change-Id: I242e2b0625bccfcfa66b7a3787d2666880e8fe27
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>