### PR TITLE
qseecom: fix 'Unable to register bus client'

### DIFF
--- a/drivers/misc/qseecom.c
+++ b/drivers/misc/qseecom.c
@@ -9258,6 +9258,9 @@ static int qseecom_probe(struct platform_device *pdev)
 		qseecom.timer_running = false;
 		qseecom.qsee_perf_client = msm_bus_scale_register_client(
 		      qseecom_platform_support);
+
+		if (!qseecom.qsee_perf_client)
+			pr_err("Unable to register bus client\n");
 	}
 
 	qseecom.whitelist_support = qseecom_check_whitelist_feature();
@@ -9287,9 +9290,6 @@ static int qseecom_probe(struct platform_device *pdev)
 	}
 	atomic_set(&qseecom.unload_app_kthread_state,
 						UNLOAD_APP_KT_SLEEP);
-
-	if (!qseecom.qsee_perf_client)
-		pr_err("Unable to register bus client\n");
 
 	atomic_set(&qseecom.qseecom_state, QSEECOM_STATE_READY);
 	return 0;


### PR DESCRIPTION
The following error message got introduced in Commit 683f99243fae
("qseecom: register qseecom client with msm bus driver"), but
under an incorrect condition:
>>>>
[    2.579027] QSEECOM: qseecom_probe: Unable to register bus client
<<<<

This error message should be generated only when bus scaling is
supported and client registration fails.

Change-Id: Ib8ef1d333233c8442a325219d9be77ec874ea928
Signed-off-by: Sarang Mairal <sarang.mairal@garmin.com>